### PR TITLE
Wrapper script

### DIFF
--- a/py3/wrapper.py
+++ b/py3/wrapper.py
@@ -1,0 +1,118 @@
+import argparse
+import logging
+import logging.config
+import os
+import subprocess
+import sys
+import traceback
+
+
+class ScriptError(Exception):
+    """Custom exception class for convenient error handling in main()."""
+
+
+def _configure_logging(verbose=True):
+    """Configure logging (console only)."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s',
+                        datefmt= '%Y-%m-%d %H:%M:%S',
+                        level=level)
+
+
+def _parse_arguments(argv):
+    """Builds ArgumentParser and returns the result of parse_args()."""
+    parser = argparse.ArgumentParser(description='Batch execution of bankform commands')
+    parser.add_argument('batch_name', help='Name of the batch to execute')
+    parser.add_argument('form', help='CBR form number (e.g. 101)')
+    parser.add_argument('dates', nargs='+', help='List of dates (YYYY or YYYY-MM-DD)')
+    parser.add_argument('--regn', help='List of bank registration numbers')
+    return parser.parse_args(argv[1:])
+
+
+def _insert_arguments(command_template, args):
+    """
+    Inserts arguments into an command template.
+    """
+    result = []
+    for template in command_template:
+        if template == '{python}':
+            result.append(sys.executable)
+        elif template == '{script}':
+            result.append('bankform.py')
+        elif template == '{form}':
+            result.append(args.form)
+        elif template == '{dates}':
+            result.extend(args.dates)
+        elif template == '{regn}':
+            if args.regn:
+                result.extend(('--regn', args.regn))
+        elif template == '{report_format}':
+            result.append('--xlsx')
+        elif '{' in template or '}' in template:
+            raise ScriptError('Unknown template variable: {!r}'.format(template))
+        else:
+            result.append(template)
+    return result
+
+
+_BATCHES = {
+    'dummy': [
+        ['{python}', '--version'],
+        ['{python}', '-c', 'print("It works!")'],
+    ],
+    'simple': [
+        ['{python}', '{script}', 'reset', 'database', 'raw'],
+        ['{python}', '{script}', 'reset', 'database', 'final'],
+        ['{python}', '{script}', 'download', '{form}', '{dates}'],
+        ['{python}', '{script}', 'unpack', '{form}', '{dates}'],
+        ['{python}', '{script}', 'make', 'csv', '{form}', '{dates}'],
+        ['{python}', '{script}', 'import', 'csv', '{form}', '{dates}'],
+        ['{python}', '{script}', 'make', 'dataset', '{form}', '{dates}'],
+        ['{python}', '{script}', 'migrate', 'dataset', '{form}'],
+        ['{python}', '{script}', 'make', 'balance'],
+        ['{python}', '{script}', 'report', 'balance', '{report_format}'],
+    ],
+    'full': [
+        ['{python}', '{script}', 'reset', 'database', 'raw'],
+        ['{python}', '{script}', 'reset', 'database', 'final'],
+        ['{python}', '{script}', 'update', '{form}', '{dates}'],
+        ['{python}', '{script}', 'make', 'dataset', '{form}', '{dates}', '{regn}'],
+        ['{python}', '{script}', 'migrate', 'dataset', '{form}'],
+        ['{python}', '{script}', 'make', 'balance'],
+        ['{python}', '{script}', 'report', 'balance', '{report_format}'],
+    ],
+}
+
+
+def main(argv):
+    args = _parse_arguments(argv)
+    logger = logging.getLogger()
+    try:
+        _configure_logging()
+        try:
+            batch = _BATCHES[args.batch_name]
+        except KeyError as ex:
+            raise ScriptError('Unknown batch: {}'.format(ex.args[0]))
+        # Insert template values, such as {form}
+        batch = [_insert_arguments(x, args) for x in batch]
+        # Execute batch
+        cwd = os.path.dirname(os.path.abspath(__file__))
+        for command in batch:
+            logger.info('Calling {!r}'.format(command))
+            process = subprocess.Popen(command, cwd=cwd)
+            returncode = process.wait()
+            if returncode != 0:
+                raise ScriptError('Child process returned {!r}'.format(returncode))
+        return 0
+    except ScriptError as ex:
+        logger.error(str(ex))
+    except Exception:
+        logger.error('Unhandled exception: {}'.format(traceback.format_exc()))
+        return 1
+    except KeyboardInterrupt:
+        logger.error('Ctrl+C is pressed')
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,14 @@ baf make balance
 baf report balance --xlsx
 ```
 
+Same result using wrapper script:
+
+```
+python wrapper.py simple 101 2015-01-01
+```
+
+See `python wrapper.py --help` for additional options.
+
 Check output by ```dir ..\output``` (Win) or ```ls dir ..\output``` (Linux).
 
 See [Testing milestones][tm] for more comments about these sample scipts.


### PR DESCRIPTION
Convenient cross-platform script to run everything at once.
Currently supports two "programs": the simple one mentioned in README, and the full one also known as "разовая выгрузка".

To run "разовая выгрузка":

    python wrapper.py full 101 2013 2015 --regn=1481,354,1000,1623,2748,3349,1326,1470,1942,2790,3340,964

(requires test_user/test_password patch - I'll update it soon)

Known issues:
1. Since bankform.py is not "fail-fast", some error occurring in the middle of downloading may go unnoticed. I recommend that in the future we introduce a policy: bankform.py should immediately crash and return nonzero exit code on the first error.